### PR TITLE
Clean up CAF::Lock

### DIFF
--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -184,14 +184,12 @@ is returned.
 sub unlock {
   my $self=shift;
   if ($self->{LOCK_SET}) {
-    flock ($self->{LOCK_FH}, LOCK_UN|LOCK_NB) or $self->error("cannot release flock on lock file: ",$self->{'LOCK_FILE'});
-    $self->{LOCK_FH}->close or $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
-    unless (unlink($self->{'LOCK_FILE'})) {
-      $self->error("cannot release lock file: ",$self->{'LOCK_FILE'});
-      return undef;
-    } else {
-      $self->{LOCK_SET}=undef;
+    # if we forced the lock LOCK_FH can be undef
+    return SUCCESS unless ($self->{LOCK_FH});
+    unless ($self->{LOCK_FH}->close) {
+      $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
     }
+    $self->{LOCK_SET}=undef;
   } else {
     $self->error("lock not held by this application instance, not unlocking");
     return undef;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -234,6 +234,8 @@ is returned.
 sub unlock {
   my $self=shift;
   if ($self->{LOCK_SET}) {
+    flock ($self->{LOCK_FH}, LOCK_UN|LOCK_NB) or $self->error("cannot release flock on lock file: ",$self->{'LOCK_FILE'});
+    $self->{LOCK_FH}->close or $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
     unless (unlink($self->{'LOCK_FILE'})) {
       $self->error("cannot release lock file: ",$self->{'LOCK_FILE'});
       return undef;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -11,6 +11,7 @@ use CAF::Reporter;
 
 use LC::Exception qw (SUCCESS throw_error);
 use FileHandle;
+use Fcntl qw(:flock);
 #use Proc::ProcessTable;
 
 use Exporter;
@@ -85,7 +86,10 @@ If a lock is set for the lock file, returns SUCCESS, undef otherwise.
 
 sub is_locked() {
   my $self=shift;
-  return SUCCESS if (-e $self->{'LOCK_FILE'});
+  if (-e $self->{'LOCK_FILE'}) {
+    my $fh=FileHandle->new("> ". $self->{'LOCK_FILE'});
+    return SUCCESS unless (flock($fh, LOCK_EX|LOCK_NB));
+  }
   return undef;
 }
 

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -48,8 +48,6 @@ CAF::Lock - Class for handling application instance locking
   unless ($lock->set_lock(10,2) {...}
   unless ($lock->set_lock(3,3,FORCE_IF_STALE)) {...}
 
-  if ($lock->is_stale()) {...} else {...};
-
   unless ($lock->unlock()) {....}
 
 
@@ -128,29 +126,6 @@ sub get_lock_pid() {
   return $1;
 }
 
-
-=pod
-
-=item is_stale()
-
-Returns SUCCESS if the lock is stale - a lock file is set but the
-corresponding PID does not exist. Returns undef otherwise.
-
-=cut
-
-sub is_stale {
-  my $self=shift;
-
-  return undef unless ($self->is_locked());
-  my $lock_pid=$self->get_lock_pid();
-  if ($lock_pid && kill(0, $lock_pid)) {
-      return undef;
-  } else {
-      return SUCCESS;
-  }
-}
-
-
 =pod
 
 =item set_lock ($retries,$timeout,$force);
@@ -167,12 +142,8 @@ If $force is set to FORCE_ALWAYS then the lockfile is just set
 again, independently if the lock is already set by another application
 instance.
 
-If $force is set to FORCE_IF_STALE then the lockfile is set if the
-application instance holding the lock is dead (PID not alive).
-
-If $force is set to FORCE_ALWAYS, or if $force is defined to
-FORCE_IF_STALE and a stale lock file is detected, then neither
-$timeout nor $retries are taken into account.
+If $force is set to FORCE_ALWAYS then neither $timeout nor $retries are taken
+into account.
 
 =cut
 

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -42,8 +42,6 @@ CAF::Lock - Class for handling application instance locking
 
   if ($lock->is_locked()) {...} else {...};
 
-  $lockpid=$lock->get_lock_pid();
-
   unless ($lock->set_lock()) {...}
   unless ($lock->set_lock(10,2) {...}
   unless ($lock->set_lock(3,3,FORCE_IF_STALE)) {...}
@@ -89,41 +87,6 @@ sub is_locked() {
     return SUCCESS unless (flock($fh, LOCK_EX|LOCK_NB));
   }
   return undef;
-}
-
-=pod
-
-=item get_lock_pid()
-
-Returns the PID file of the application holding the lock, undef if no
-lockfile found
-
-=cut
-
-sub get_lock_pid() {
-  my $self=shift;
-
-  return undef unless ($self->is_locked());
-  return $$ if ($self->{'LOCK_SET'});
-  my $lf=FileHandle->new("< " . $self->{'LOCK_FILE'});
-  unless ($lf) {
-    $self->error("cannot open lock file for read: ".$self->{'LOCK_FILE'});
-    return undef;
-  }
-  my $pid=$lf->getline();
-  unless (defined $pid) {
-    $self->error("cannot read from lock file: ".$self->{'LOCK_FILE'});
-    return undef;
-  }
-  unless ($lf->close()) {
-    $self->error("cannot close lock file: ".$self->{'LOCK_FILE'});
-    return undef;
-  }
-  if ($pid !~ m{^(\d+)$}) {
-      $self->error("Strange PID $pid holding lock $self->{LOCK_FILE}");
-      return undef;
-  }
-  return $1;
 }
 
 =pod
@@ -201,8 +164,6 @@ sub try_lock {
     $self->error("cannot flock lock file: ".$self->{'LOCK_FILE'});
     return undef;
   }
-  $lf->autoflush;
-  print $lf $$;
   $self->{LOCK_FH}=$lf;
   $self->{LOCK_SET}=1;
   return SUCCESS;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -9,22 +9,22 @@ use strict;
 use CAF::Object;
 use CAF::Reporter;
 
-use LC::Exception qw (SUCCESS throw_error);
+use LC::Exception qw(SUCCESS throw_error);
 use FileHandle;
 use Fcntl qw(:flock);
-#use Proc::ProcessTable;
 
 use Exporter;
 use vars qw(@ISA @EXPORT @EXPORT_OK);
 
 @ISA = qw(CAF::Reporter CAF::Object Exporter);
 
-@EXPORT_OK = qw(FORCE_ALWAYS FORCE_IF_STALE);
+@EXPORT_OK = qw(FORCE_NONE FORCE_ALWAYS FORCE_IF_STALE);
 
 
-use constant FORCE_NONE => 0;
-use constant FORCE_ALWAYS => 1;
-use constant FORCE_IF_STALE => 2;
+use constant FORCE_NONE     => 0;
+use constant FORCE_ALWAYS   => 1;
+use constant FORCE_IF_STALE => 2;  # for backwards compatibility only
+                                   # has no effect now
 
 
 =pod
@@ -35,19 +35,15 @@ CAF::Lock - Class for handling application instance locking
 
 =head1 SYNOPSIS
 
-
   use CAF::Lock;
 
-  $lock=CAF::Lock->new('/var/lock/quattor/spma');
-
-  if ($lock->is_locked()) {...} else {...};
+  $lock = CAF::Lock->new('/var/lock/quattor/spma');
 
   unless ($lock->set_lock()) {...}
-  unless ($lock->set_lock(10,2) {...}
-  unless ($lock->set_lock(3,3,FORCE_IF_STALE)) {...}
+  unless ($lock->set_lock(10, 2) {...}
+  unless ($lock->set_lock(3, 3, FORCE_ALWAYS)) {...}
 
   unless ($lock->unlock()) {....}
-
 
 =head1 INHERITANCE
 
@@ -56,7 +52,6 @@ CAF::Lock - Class for handling application instance locking
 =head1 DESCRIPTION
 
 The B<CAF::Lock> class provides methods for handling application locking.
-
 
 =over
 
@@ -70,51 +65,31 @@ The B<CAF::Lock> class provides methods for handling application locking.
 
 =back
 
-=head2 Public methods
+=head1 PUBLIC METHODS
 
 =over 4
 
-=item is_locked()
+=item set_lock(I<retries>, I<timeout>, I<force>)
 
-If a lock is set for the lock file, returns SUCCESS, undef otherwise.
-
-=cut
-
-sub is_locked() {
-  my $self=shift;
-  if (-e $self->{'LOCK_FILE'}) {
-    my $fh=FileHandle->new("> ". $self->{'LOCK_FILE'});
-    return SUCCESS unless (flock($fh, LOCK_EX|LOCK_NB));
-  }
-  return undef;
-}
-
-=pod
-
-=item set_lock ($retries,$timeout,$force);
-
-Tries $retries times to set the lock. If $force is set to FORCE_NONE
+Tries I<retries> times to set the lock.  If I<force> is set to B<FORCE_NONE>
 or not defined and the lock is set, it sleeps for
-rand($timeout). Writes the current PID ($$) into the lock
-file. Returns SUCCESS or undef on failure.
+rand(I<timeout>).  Returns B<SUCCESS>, or B<undef> on failure.
 
-If $retries or $timeout are not defined or set to 0, only a single
+If I<retries> or I<timeout> are not defined or set to 0, only a single
 attempt is done to acquire the lock.
 
-If $force is set to FORCE_ALWAYS then the lockfile is just set
-again, independently if the lock is already set by another application
-instance.
-
-If $force is set to FORCE_ALWAYS then neither $timeout nor $retries are taken
+If I<force> is set to B<FORCE_ALWAYS> then the lock file is just set
+again, even if the lock is already set by another application
+instance, and neither I<timeout> nor I<retries> are taken
 into account.
 
 =cut
 
 sub set_lock {
-  my ($self,$retries,$timeout,$force)=@_;
+  my ($self, $retries, $timeout, $force) = @_;
 
-  $retries=0 unless (defined $retries);
-  $timeout=0 unless (defined $retries);
+  $retries = 0 unless (defined $retries);
+  $timeout = 0 unless (defined $retries);
 
   if ($self->{LOCK_SET}) {
     # oops.
@@ -122,74 +97,45 @@ sub set_lock {
     return undef;
   }
 
-  my $tries=0;
-  my $lock;
-  while(1) {
+  my $tries = 0;
+  do {
+    if ($tries > 0) {
+      $self->verbose("lock file is already held, try $tries out of $retries");
+      sleep(rand($timeout));
+    }
     $tries++;
-    $lock = $self->try_lock();
-    if ($force == FORCE_ALWAYS) {
-      $self->{LOCK_SET} = 1;
-      $self->verbose("locking failed, but you used the force so here you go");
-      return SUCCESS;
-    }
-    return SUCCESS if ($lock);
+    return SUCCESS if $self->_try_lock($force);
+  } while ($tries < $retries && $timeout);
 
-    if ($tries >= $retries) {
-      $self->error("cannot acquire lock file: ".$self->{'LOCK_FILE'});
-      return undef;
-    }
-
-    $self->verbose("lockfile is already held, try $tries out of $retries");
-    my $sleep=rand($timeout);
-    sleep($sleep);
-  }
+  $self->error("cannot acquire lock: " . $self->{LOCK_FILE});
+  return undef;
 }
 
 =pod
 
-=item try_lock
+=item unlock()
 
-Create the lockfile and return SUCCESS if we was able to flock() the file.
-
-=cut
-
-sub try_lock {
-  my ($self) = @_;
-  my $lf=FileHandle->new("> " . $self->{'LOCK_FILE'});
-  if ( !$lf ) {
-    $self->error("cannot create lock file: ".$self->{'LOCK_FILE'});
-    return undef;
-  }
-  my $flockstatus = flock ($lf, LOCK_EX|LOCK_NB);
-  if ( !$flockstatus ) {
-    $self->error("cannot flock lock file: ".$self->{'LOCK_FILE'});
-    return undef;
-  }
-  $self->{LOCK_FH}=$lf;
-  $self->{LOCK_SET}=1;
-  return SUCCESS;
-}
-
-=pod
-
-=item unlock
-
-Releases the lock and returns SUCCESS. Reports an error and returns
-undef if the lock file cannot be released. If the object (application
-instance) does not hold the lockfile, an error is reported and undef
+Releases the lock and returns B<SUCCESS>.  Reports an error and returns
+B<undef> if the lock cannot be released.  If the object (application
+instance) does not hold the lock, an error is reported and B<undef>
 is returned.
 
 =cut
 
 sub unlock {
-  my $self=shift;
+  my $self = shift;
   if ($self->{LOCK_SET}) {
     # if we forced the lock LOCK_FH can be undef
-    return SUCCESS unless ($self->{LOCK_FH});
-    unless ($self->{LOCK_FH}->close) {
-      $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
+    if ($self->{LOCK_FH}) {
+      unless (flock($self->{LOCK_FH}, LOCK_UN)) {
+        $self->error("cannot release lock: ",$self->{LOCK_FILE});
+        return undef;
+      }
+      $self->error("cannot close lock file: ",$self->{LOCK_FILE})
+          unless $self->{LOCK_FH}->close();
     }
-    $self->{LOCK_SET}=undef;
+    $self->{LOCK_SET} = undef;
+    $self->{LOCK_FH} = undef;
   } else {
     $self->error("lock not held by this application instance, not unlocking");
     return undef;
@@ -200,9 +146,9 @@ sub unlock {
 
 =pod
 
-=item is_set
+=item is_set()
 
-Returns SUCCESS if lock is set by application instance, undef otherwise
+Returns B<SUCCESS> if lock is set by application instance, B<undef> otherwise.
 
 =cut
 
@@ -212,31 +158,78 @@ sub is_set {
   return undef;
 }
 
+##############################################################################
+#
+# The following methods are provided for backwards compatibility only
+# and have been deprecated
+#
+sub get_lock_pid {
+  return undef;
+}
+
+sub is_stale {
+  return undef;
+}
+
+*is_locked = \&is_set;
+##############################################################################
 
 
 =pod
 
 =back
 
-=head2 Private methods
+=head1 PRIVATE METHODS
 
 =over 4
 
-=item _initialize($lockfilename)
+=item _initialize(I<lockfilename>)
 
-initialize the object. Called by new($lockfilename).
+Initialize the object.  Called by new(I<lockfilename>).
 
 =cut
 
 sub _initialize ($$$) {
   my ($self,$lockfilename) = @_;
 
-  $self->{'LOCK_SET'}=undef;
-  $self->{'LOCK_FILE'} = $lockfilename;
+  $self->{LOCK_SET} = undef;
+  $self->{LOCK_FILE} = $lockfilename;
   return SUCCESS;
 
 }
 
+=pod
+
+=item _try_lock(I<force>)
+
+Called by set_lock() to create the lock file and return B<SUCCESS> if we were
+able to flock() the file.
+
+If I<force> is set to B<FORCE_ALWAYS> then this method will return B<SUCCESS>
+even if flock() was unsuccessful.
+
+=cut
+
+sub _try_lock {
+  my ($self, $force) = @_;
+  my $lf = FileHandle->new("> " . $self->{LOCK_FILE});
+  unless ($lf) {
+    $self->error("cannot create lock file: " . $self->{LOCK_FILE});
+    return undef;
+  }
+  unless (flock($lf, LOCK_EX|LOCK_NB)) {
+    # Could not get the lock
+    return undef unless $force == FORCE_ALWAYS;
+
+    # In force mode, continue but don't save the filehandle
+    $lf->close();
+    $lf = undef;
+  }
+
+  $self->{LOCK_FH} = $lf;
+  $self->{LOCK_SET} = 1;
+  return SUCCESS;
+}
 
 =pod
 

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -278,26 +278,6 @@ sub _initialize ($$$) {
 }
 
 
-
-=pod
-
-=item DESTROY
-
-called during garbage collection. Invokes unlock() if lock is set by
-application instance.
-
-=cut
-
-
-sub DESTROY {
-  my $self = shift;
-  # We unlock only on the process that owns the lock.  Otherwise this
-  # might be a forked process that is exiting and shouldn't sweep
-  # under its parent's feet.
-  $self->unlock() if $self->{LOCK_SET} && $self->get_lock_pid() == $$;
-}
-
-
 =pod
 
 =back

--- a/src/test/perl/lock.t
+++ b/src/test/perl/lock.t
@@ -13,38 +13,10 @@ unlink(LOCK_TEST);
 my $lock=CAF::Lock->new(LOCK_TEST);
 
 ok(!$lock->is_locked(), "Unlocked at start");
-my $lockpid=$lock->get_lock_pid();
-
-is($lockpid, undef, "Lock PID undefined on unaquired lock");
 
 ok($lock->set_lock(), "Lock set");
 ok($lock->is_locked(), "Locked on request");
-
-is($lock->get_lock_pid(), $$, "Lock PID correctly set on locked object");
-
 ok(!$lock->is_stale(), "Lock is NOT stale");
-
 ok($lock->unlock(), "Lock released");
-
-open(my $fh, ">", LOCK_TEST);
-if (!kill(0, $$+1)) {
-    print $fh $$+1;
-    close($fh);
-    ok($lock->is_stale(), "Lock by non-existing process is stale");
-}
-
-ok(!$lock->set_lock(), "Non-forced lock on stalled lock not acuired");
-ok($lock->set_lock(0, 0, FORCE_IF_STALE), "Forced lock on stalled resource aquired");
-$lock->unlock();
-
-open($fh, ">", LOCK_TEST);
-close($fh);
-
-ok($lock->is_stale(), "Lock on empty lock file is stale");
-ok($lock->set_lock(0, 0, FORCE_IF_STALE), "Forced lock on empty lock file aquired");
-
-# How does it handle when an empty lock file is there?
-
-
 
 done_testing();


### PR DESCRIPTION
Tidy up `flock()` code introduced by @ttyS4 , other general tidy-up and make the test suite work.

Note that the following methods are now deprecated:
- `get_lock_pid()` - no longer implemented due to a race condition.  Always returns `undef`.  If you really need this information, ask the OS who has the file lock.
- `is_stale()` - locks cannot be stale anymore.  Always returns `undef`.
- `is_locked()` - is now an alias for `is_set()`.
